### PR TITLE
Add citation extraction library and CLI utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,66 @@
-# My Project
+# Citation Extraction Tool
+
+This project provides a lightweight Python utility that can scan arbitrary text for
+citations, references, and quotations. For each artefact it captures the
+surrounding context and generates ready-to-use prompts that can be fed to an AI
+model to recover complete bibliographic information.
+
+## Features
+
+- Detects parenthetical citations such as `(Doe, 2020)` and numeric references
+  like `[1, 2]`.
+- Extracts quotations and preserves the sentence where they appear.
+- Generates structured prompts tailored for AI models to retrieve authoritative
+  references or identify quote sources.
+- Includes a simple command-line interface and composable Python API.
+
+## Installation
+
+The package follows a standard `src` layout. You can install it in editable mode
+within a virtual environment:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .
+```
+
+## Usage
+
+### Python API
+
+```python
+from citation_tool import analyze_text
+
+text = "According to recent studies (Doe, 2021), innovation is accelerating."
+result = analyze_text(text)
+
+for citation in result["citations"]:
+    print(citation.text, citation.context)
+
+for prompt in result["prompts"]:
+    print(prompt.prompt)
+```
+
+### Command Line Interface
+
+Analyse a text file and return a JSON payload with citations, quotations, and
+prompts:
+
+```bash
+python -m citation_tool.cli path/to/document.txt
+```
+
+Alternatively, read from standard input and emit a human-friendly summary:
+
+```bash
+echo "According to (Doe, 2020) ..." | python -m citation_tool.cli --format text
+```
+
+## Testing
+
+Run the unit tests with:
+
+```bash
+pytest
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,31 @@
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "citation-tool"
+version = "0.1.0"
+description = "Extract citations, quotations, and generate AI prompts for bibliographies."
+authors = [{ name = "AI Assistant" }]
+readme = "README.md"
+requires-python = ">=3.9"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+]
+dependencies = []
+
+[project.optional-dependencies]
+dev = ["pytest>=7"]
+
+[project.urls]
+Homepage = "https://example.com/citation-tool"
+
+[tool.setuptools]
+packages = ["citation_tool"]
+package-dir = {"" = "src"}
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-q"

--- a/src/citation_tool/__init__.py
+++ b/src/citation_tool/__init__.py
@@ -1,0 +1,14 @@
+"""Utilities for extracting citations, references, and quotations from text."""
+
+from .models import Citation, Quotation, Prompt
+from .analyzer import analyze_text, extract_citations, extract_quotations, generate_prompts
+
+__all__ = [
+    "Citation",
+    "Quotation",
+    "Prompt",
+    "analyze_text",
+    "extract_citations",
+    "extract_quotations",
+    "generate_prompts",
+]

--- a/src/citation_tool/analyzer.py
+++ b/src/citation_tool/analyzer.py
@@ -1,0 +1,146 @@
+"""Core logic for extracting citations, quotations and prompts."""
+
+from __future__ import annotations
+
+import re
+from typing import Iterable, List
+
+from .models import Citation, Prompt, Quotation
+
+_SENTENCE_END_RE = re.compile(r"(?<=[.!?])\s+(?=[A-Z0-9\"])")
+_PARENTHEICAL_CITATION_RE = re.compile(r"\((?P<citation>[^()]*?\d{4}[^()]*)\)")
+_NUMERIC_CITATION_RE = re.compile(r"\[(?P<citation>\d+(?:\s*,\s*\d+)*)\]")
+_QUOTE_RE = re.compile(r'"(?P<quote>[^"]{3,})"')
+
+
+def _split_sentences(text: str) -> List[str]:
+    """A very small sentence tokenizer."""
+
+    cleaned = " ".join(text.split())
+    if not cleaned:
+        return []
+    sentences = _SENTENCE_END_RE.split(cleaned)
+    return [sentence.strip() for sentence in sentences if sentence.strip()]
+
+
+def _sentence_lookup(sentences: Iterable[str]) -> List[str]:
+    return list(sentences)
+
+
+def _find_sentence(context_sentences: List[str], match_span: tuple[int, int], text: str) -> str:
+    start, end = match_span
+    for sentence in context_sentences:
+        idx = text.find(sentence)
+        if idx == -1:
+            continue
+        if idx <= start < idx + len(sentence):
+            return sentence
+    snippet = text[max(0, start - 75) : min(len(text), end + 75)]
+    return " ".join(snippet.split())
+
+
+def extract_citations(text: str) -> List[Citation]:
+    """Extract in-text citations together with their surrounding context."""
+
+    sentences = _sentence_lookup(_split_sentences(text))
+    citations: List[Citation] = []
+
+    for match in _PARENTHEICAL_CITATION_RE.finditer(text):
+        citation_text = match.group("citation").strip()
+        context = _find_sentence(sentences, match.span(), text)
+        citations.append(
+            Citation(text=citation_text, context=context, style="parenthetical")
+        )
+
+    for match in _NUMERIC_CITATION_RE.finditer(text):
+        citation_text = match.group("citation").strip()
+        context = _find_sentence(sentences, match.span(), text)
+        citations.append(Citation(text=citation_text, context=context, style="numeric"))
+
+    seen = set()
+    unique_citations: List[Citation] = []
+    for citation in citations:
+        key = (citation.text, citation.context)
+        if key in seen:
+            continue
+        seen.add(key)
+        unique_citations.append(citation)
+
+    return unique_citations
+
+
+def extract_quotations(text: str) -> List[Quotation]:
+    """Extract quotations with their surrounding context."""
+
+    sentences = _sentence_lookup(_split_sentences(text))
+    quotations: List[Quotation] = []
+
+    for match in _QUOTE_RE.finditer(text):
+        quote_text = match.group("quote").strip()
+        if not quote_text:
+            continue
+        context = _find_sentence(sentences, match.span(), text)
+        quotations.append(Quotation(text=quote_text, context=context))
+
+    return quotations
+
+
+def generate_prompts(
+    citations: Iterable[Citation], quotations: Iterable[Quotation]
+) -> List[Prompt]:
+    """Builds prompts to help an AI model recover bibliographic information."""
+
+    prompts: List[Prompt] = []
+
+    for citation in citations:
+        prompt_text = (
+            "You are a research assistant. Given the following in-text citation, "
+            "identify the most likely bibliographic reference with complete "
+            "details (authors, title, venue, year, publisher as applicable). If "
+            "multiple works are implied, list each separately.\n"
+            f"Citation: {citation.text}\n"
+            f"Context: {citation.context}\n"
+            "Respond with a structured JSON array where each entry contains "
+            "`title`, `authors`, `venue`, `year`, and `additional_info`."
+        )
+        prompts.append(
+            Prompt(
+                target="citation",
+                subject=citation.text,
+                context=citation.context,
+                prompt=prompt_text,
+            )
+        )
+
+    for quotation in quotations:
+        prompt_text = (
+            "You are a literature analyst. Determine the original source of the "
+            "following quotation and provide bibliographic details if possible.\n"
+            f"Quotation: \"{quotation.text}\"\n"
+            f"Context: {quotation.context}\n"
+            "Respond in JSON with fields `suspected_source`, `supporting_evidence`, "
+            "and `confidence` (0-1)."
+        )
+        prompts.append(
+            Prompt(
+                target="quotation",
+                subject=quotation.text,
+                context=quotation.context,
+                prompt=prompt_text,
+            )
+        )
+
+    return prompts
+
+
+def analyze_text(text: str) -> dict[str, List[Prompt] | List[Citation] | List[Quotation]]:
+    """Convenience helper that extracts all artefacts and prompts."""
+
+    citations = extract_citations(text)
+    quotations = extract_quotations(text)
+    prompts = generate_prompts(citations, quotations)
+    return {
+        "citations": citations,
+        "quotations": quotations,
+        "prompts": prompts,
+    }

--- a/src/citation_tool/cli.py
+++ b/src/citation_tool/cli.py
@@ -1,0 +1,67 @@
+"""Command line entry point for the citation extraction tool."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from .analyzer import analyze_text
+
+
+def _read_input(path: str | None) -> str:
+    if path is None or path == "-":
+        return sys.stdin.read()
+    return Path(path).read_text(encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Extract citations, quotations, and generate AI prompts."
+    )
+    parser.add_argument(
+        "source",
+        nargs="?",
+        default="-",
+        help="Path to the text file to analyse. Reads from stdin when omitted or '-'.",
+    )
+    parser.add_argument(
+        "--format",
+        choices={"json", "text"},
+        default="json",
+        help="Output format (default: json).",
+    )
+
+    args = parser.parse_args(argv)
+    text = _read_input(args.source)
+    analysis = analyze_text(text)
+
+    if args.format == "json":
+        print(
+            json.dumps(
+                {
+                    "citations": [citation.__dict__ for citation in analysis["citations"]],
+                    "quotations": [
+                        quotation.__dict__ for quotation in analysis["quotations"]
+                    ],
+                    "prompts": [prompt.__dict__ for prompt in analysis["prompts"]],
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+        )
+    else:
+        for citation in analysis["citations"]:
+            print(f"Citation: {citation.text}\n  Context: {citation.context}\n")
+        for quotation in analysis["quotations"]:
+            print(f"Quotation: \"{quotation.text}\"\n  Context: {quotation.context}\n")
+        print("Prompts:\n")
+        for prompt in analysis["prompts"]:
+            print(f"[{prompt.target}] {prompt.prompt}\n")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/citation_tool/models.py
+++ b/src/citation_tool/models.py
@@ -1,0 +1,33 @@
+"""Data models used by the citation extraction utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+
+@dataclass(slots=True)
+class Citation:
+    """Represents an in-text citation."""
+
+    text: str
+    context: str
+    style: Literal["parenthetical", "numeric", "unknown"] = "unknown"
+
+
+@dataclass(slots=True)
+class Quotation:
+    """Represents a quoted passage."""
+
+    text: str
+    context: str
+
+
+@dataclass(slots=True)
+class Prompt:
+    """A prompt targeted at an AI model to help recover bibliographic metadata."""
+
+    target: Literal["citation", "quotation"]
+    subject: str
+    context: str
+    prompt: str

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_PATH = PROJECT_ROOT / "src"
+if str(SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH))

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -1,0 +1,32 @@
+from citation_tool.analyzer import analyze_text, extract_citations, extract_quotations
+
+
+SAMPLE_TEXT = (
+    "According to later studies (Smith and Wesson, 2019), the results were inconclusive. "
+    "However, subsequent work [4, 5] argued otherwise. As the report stated, "
+    '\"Innovation distinguishes between a leader and a follower,\" Apple\'s founder once said.'
+)
+
+
+def test_extract_citations_parenthetical():
+    citations = extract_citations(SAMPLE_TEXT)
+    assert any(c.text == "Smith and Wesson, 2019" for c in citations)
+
+
+def test_extract_citations_numeric():
+    citations = extract_citations(SAMPLE_TEXT)
+    assert any(c.text == "4, 5" for c in citations)
+
+
+def test_extract_quotations():
+    quotations = extract_quotations(SAMPLE_TEXT)
+    assert any(
+        "Innovation distinguishes between a leader and a follower" in q.text
+        for q in quotations
+    )
+
+
+def test_analyze_text_structure():
+    result = analyze_text(SAMPLE_TEXT)
+    assert {"citations", "quotations", "prompts"} <= set(result)
+    assert len(result["prompts"]) == len(result["citations"]) + len(result["quotations"])


### PR DESCRIPTION
## Summary
- add a `citation_tool` package that extracts in-text citations and quotations
- generate AI-ready prompts plus a command-line interface and documentation
- configure packaging metadata and regression tests for the analyzer

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e123f61cc483228cbacdc4cbbc76a4